### PR TITLE
[I Am Your Beast] feat: add resetting for IL mode when transitioning out of a scene

### DIFF
--- a/IAYB/IAYB.asl
+++ b/IAYB/IAYB.asl
@@ -10,7 +10,11 @@ startup
 
 init
 {
-    vars.Helper.TryLoad = (Func<dynamic, bool>)(mono => {
+    vars.Helper.TryLoad = (Func<dynamic, bool>)(mono =>
+    {
+        // used to identify if we're on Mercy (25)
+        // note that this is only level number within a pack. which means ids <= 12 are ambiguous (multiple levels share that number)
+        vars.Helper["level"] = mono.Make<int>("GameManager", "instance", "levelController", "informationSetter", "levelInformation", "levelNumber");
 
         //Level states: 0 - intro; 1 - active; 2 - completed; 3 - failed.
         vars.Helper["levelState"] = mono.Make<byte>("GameManager", "instance", "levelController", "levelState");
@@ -61,7 +65,8 @@ split
 
 reset
 {
-    if (settings["ILs"] && old.sceneTransition != 0 && current.sceneTransition == 0) {
+    // disable for Mercy since it transitions out before the level finishes
+    if (settings["ILs"] && current.level != 25 && old.sceneTransition != 0 && current.sceneTransition == 0) {
         return true;
     }
 }

--- a/IAYB/IAYB.asl
+++ b/IAYB/IAYB.asl
@@ -43,7 +43,7 @@ isLoading
 
 start
 {
-    if (settings["ILs"] == true) {
+    if (settings["ILs"]) {
         return current.sceneTransition == 2 && old.tracking == false && current.tracking == true;
     } else {
         return current.sceneTransition == 2 && old.tracking == false && current.tracking == true && current.destination == "Scenes/!___STORY SCENES/#01a_Special_Tutorial";
@@ -57,4 +57,11 @@ split
     } else {
         return (old.destination == "#01c_Special_Tutorial" && current.destination == "Scenes/UI/Menus/LevelSelect") || (old.levelState == 1 && current.levelState == 2);
     };
+}
+
+reset
+{
+    if (settings["ILs"] && old.sceneTransition != 0 && current.sceneTransition == 0) {
+        return true;
+    }
 }


### PR DESCRIPTION
This can be disabled using the regular "reset" checkbox in LiveSplit (disables the reset block altogether).

Otherwise self-explanatory